### PR TITLE
feat: implement text to sql and duck-db query #19

### DIFF
--- a/backend/query_api.py
+++ b/backend/query_api.py
@@ -1,6 +1,9 @@
+import json
+import logging
 import os
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
+import duckdb
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from qdrant_client import QdrantClient
@@ -11,11 +14,21 @@ from dotenv import load_dotenv
 
 load_dotenv()  # .env 파일 로드
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 # --- 설정 (환경 변수에서 읽기) ---
 
 QDRANT_HOST = os.getenv("QDRANT_HOST", "localhost")
 QDRANT_PORT = int(os.getenv("QDRANT_PORT", "6333"))
 COLLECTION_NAME = os.getenv("QDRANT_COLLECTION", "crypto_news")
+
+# MinIO (비트코인 거래 Parquet, trade-consumer가 silver/에 적재)
+# Backend는 DuckDB In-Memory + httpfs로 MinIO Parquet 직접 조회 (Lock 없음)
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "http://localhost:9000")
+MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin")
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "password123")
+MINIO_TRADE_BUCKET = os.getenv("MINIO_TRADE_BUCKET", "trade-lake")
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if not OPENAI_API_KEY:
@@ -40,6 +53,217 @@ app.add_middleware(
 
 client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
 openai_client = OpenAI(api_key=OPENAI_API_KEY)
+
+
+@app.on_event("startup")
+def _log_minio_trade():
+    """기동 시 MinIO 비트코인 거래 Parquet 경로 로그."""
+    logger.info(
+        "MinIO trade Parquet: s3://%s/silver/**/*.parquet (endpoint=%s)",
+        MINIO_TRADE_BUCKET,
+        MINIO_ENDPOINT,
+    )
+
+
+# --- DuckDB In-Memory + MinIO Parquet (비트코인 거래, Lock 없음) ---
+
+def get_duckdb_minio_connection() -> duckdb.DuckDBPyConnection:
+    """
+    MinIO(S3)에 연결된 In-Memory DuckDB 세션 생성.
+    질문마다 새 세션으로 Stateless, Lock 문제 없음.
+    """
+    con = duckdb.connect(database=":memory:")
+    con.execute("INSTALL httpfs; LOAD httpfs;")
+    endpoint = MINIO_ENDPOINT.replace("http://", "").replace("https://", "")
+    con.execute(f"SET s3_endpoint='{endpoint}';")
+    con.execute(f"SET s3_access_key_id='{MINIO_ACCESS_KEY}';")
+    con.execute(f"SET s3_secret_access_key='{MINIO_SECRET_KEY}';")
+    con.execute("SET s3_use_ssl=false;")
+    con.execute("SET s3_url_style='path';")
+    return con
+
+
+def _is_read_only_sql(sql: str) -> bool:
+    """SELECT만 허용 (DELETE/UPDATE/INSERT/DROP 등 차단)."""
+    stripped = sql.strip().upper()
+    if not stripped.startswith("SELECT"):
+        return False
+    blocked = ("DELETE", "UPDATE", "INSERT", "DROP", "CREATE", "ALTER", "TRUNCATE")
+    for w in blocked:
+        if w in stripped:
+            return False
+    return True
+
+
+def query_duckdb(sql_query: str) -> str:
+    """
+    MinIO Silver Parquet를 read_parquet로 조회. trades 뷰로 SELECT만 실행.
+    DuckDB In-Memory 일회용 세션 → Lock 없음.
+    """
+    if not _is_read_only_sql(sql_query):
+        return "Error: Only SELECT queries are allowed."
+    con = None
+    try:
+        con = get_duckdb_minio_connection()
+        parquet_path = f"s3://{MINIO_TRADE_BUCKET}/silver/**/*.parquet"
+        con.execute(f"""
+            CREATE OR REPLACE VIEW trades AS
+            SELECT * FROM read_parquet('{parquet_path}')
+        """)
+        result = con.execute(sql_query).df()
+        return result.to_json(orient="records", date_format="iso")
+    except Exception as e:
+        return f"Error: {str(e)}"
+    finally:
+        if con is not None:
+            con.close()
+
+
+def _search_news_impl(query: str, limit: int = 3) -> tuple[str, list]:
+    """
+    뉴스 벡터 검색 (RAG). 통합 /ask 에서 search_news 도구로 사용.
+    Returns: (LLM용 컨텍스트 문자열, reference_news 목록)
+    """
+    query_response = openai_client.embeddings.create(
+        input=query,
+        model="text-embedding-3-small",
+    )
+    query_vector = query_response.data[0].embedding
+    try:
+        search_response = client.query_points(
+            collection_name=COLLECTION_NAME,
+            query=query_vector,
+            limit=limit,
+        )
+        points = search_response.points if hasattr(search_response, "points") else []
+    except Exception:
+        return "뉴스 검색 중 오류가 발생했습니다.", []
+
+    if not points:
+        return "관련 뉴스를 찾을 수 없습니다.", []
+
+    context_list = []
+    sources = []
+    for res in points:
+        if hasattr(res, "payload"):
+            payload = res.payload
+            score = res.score if hasattr(res, "score") else 0.0
+        else:
+            payload = res.get("payload", {}) if isinstance(res, dict) else {}
+            score = res.get("score", 0.0) if isinstance(res, dict) else 0.0
+        title = payload.get("title", "제목 없음")
+        content = payload.get("content", "")
+        url = payload.get("url", "")
+        context_list.append(f"[{title}]\n{content}")
+        sources.append({
+            "title": title,
+            "url": url,
+            "source": payload.get("source", ""),
+            "published_at": payload.get("published_at", ""),
+            "score": score,
+        })
+    context_text = "\n\n---\n\n".join(context_list)
+    return context_text, sources
+
+
+# 통합 질의: 뉴스 RAG + DuckDB 둘 다 도구로 제공
+UNIFIED_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_news",
+            "description": "가상자산(코인) 관련 최신 뉴스를 검색합니다. 뉴스 내용·가격 동향·이슈를 물어볼 때 사용하세요.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "검색할 질문 또는 키워드 (예: 비트코인 가격, 이더리움 뉴스)"},
+                    "limit": {"type": "integer", "description": "가져올 뉴스 개수 (기본 3)", "default": 3},
+                },
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "query_duckdb",
+            "description": "Bitcoin(BTC/USDT) 거래 데이터에서 SQL로 집계·조회합니다. 평균가, 거래량, 최근 가격 등 숫자/통계 질문에 사용하세요.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "sql_query": {
+                        "type": "string",
+                        "description": (
+                            "실행할 SQL. 테이블명 'trades', 컬럼: trade_id, symbol, price, quantity, amount, side(BUY/SELL), trade_time, received_at. "
+                            "예: SELECT AVG(price) as avg_price FROM trades WHERE trade_time >= now() - interval '1 hour'"
+                        ),
+                    }
+                },
+                "required": ["sql_query"],
+            },
+        },
+    },
+]
+
+
+def _ask_unified(question: str, limit: int = 3) -> tuple[str, list]:
+    """
+    한 질문으로 뉴스·비트코인 거래 모두 처리. LLM이 필요한 도구(search_news, query_duckdb)를 선택해 호출.
+    Returns: (answer, reference_news)
+    """
+    system = (
+        "당신은 가상자산(코인) 전문가입니다. "
+        "필요하면 search_news(뉴스 검색)와 query_duckdb(비트코인 거래 데이터 SQL 조회) 도구를 사용하세요. "
+        "질문이 뉴스/이슈 관련이면 search_news, 평균가·거래량 등 숫자/통계면 query_duckdb를 사용하고, 둘 다 필요하면 둘 다 호출하세요. "
+        "답변은 한국어로 작성하세요.\n\n"
+        "뉴스 관련 답변 시 중요 규칙:\n"
+        "- 뉴스에 없는 내용은 절대 지어내지 마세요.\n"
+        "- 모르는 내용이면 \"제공된 뉴스에는 해당 정보가 없습니다\"라고 답변하세요.\n"
+        "- 가능하면 구체적인 날짜, 숫자, 출처를 포함하세요."
+    )
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": question},
+    ]
+    collected_refs: list = []
+
+    response = openai_client.chat.completions.create(
+        model="gpt-4o",
+        messages=messages,
+        tools=UNIFIED_TOOLS,
+    )
+    msg = response.choices[0].message
+
+    while getattr(msg, "tool_calls", None):
+        messages.append(msg)
+        for tc in msg.tool_calls:
+            try:
+                args = json.loads(tc.function.arguments)
+            except json.JSONDecodeError:
+                messages.append({"role": "tool", "tool_call_id": tc.id, "content": "Error: Invalid arguments."})
+                continue
+            if tc.function.name == "search_news":
+                q = args.get("query", question)
+                lim = args.get("limit", limit)
+                context_text, sources = _search_news_impl(q, lim)
+                collected_refs.extend(sources)
+                content = context_text
+            elif tc.function.name == "query_duckdb":
+                sql = args.get("sql_query", "")
+                content = query_duckdb(sql)
+            else:
+                content = "Unknown tool."
+            messages.append({"role": "tool", "tool_call_id": tc.id, "content": content})
+
+        response = openai_client.chat.completions.create(
+            model="gpt-4o",
+            messages=messages,
+            tools=UNIFIED_TOOLS,
+        )
+        msg = response.choices[0].message
+
+    answer = msg.content or "답변을 생성할 수 없습니다."
+    return answer, collected_refs
 
 
 @app.get("/")
@@ -76,113 +300,21 @@ async def health_check():
 
 
 @app.get("/ask")
-async def ask_news(question: str, limit: int = 3):
+async def ask_unified(question: str, limit: int = 3):
     """
-    뉴스 기반 질의응답 API.
-
-    Args:
-        question: 사용자의 질문
-        limit: 검색할 뉴스 개수 (기본값: 3)
+    통합 질의응답 API. 한 질문으로 뉴스(RAG)와 비트코인 거래(DuckDB) 모두 처리합니다.
+    LLM이 질문에 따라 search_news, query_duckdb 도구를 선택해 호출합니다.
 
     Returns:
         answer: LLM이 생성한 답변
-        reference_news: 참조된 뉴스 목록
+        reference_news: 참조된 뉴스 목록 (뉴스 검색 시에만)
     """
     if not question or not question.strip():
         raise HTTPException(status_code=400, detail="질문을 입력해주세요.")
 
     try:
-        # 1. 사용자 질문을 벡터로 변환 (적재할 때와 동일한 모델 사용)
-        query_response = openai_client.embeddings.create(
-            input=question,
-            model="text-embedding-3-small",
-        )
-        query_vector = query_response.data[0].embedding
-
-        # 2. Qdrant에서 관련 뉴스 검색
-        # 최신 qdrant-client에서는 query_points 사용 (권장)
-        try:
-            search_response = client.query_points(
-                collection_name=COLLECTION_NAME,
-                query=query_vector,
-                limit=limit,
-            )
-            # query_points 결과는 .points 속성으로 접근
-            points = search_response.points if hasattr(search_response, 'points') else []
-        except Exception as e:
-            # 상세한 에러 정보 포함
-            error_msg = str(e)
-            error_type = type(e).__name__
-            raise HTTPException(
-                status_code=500,
-                detail=f"Qdrant 검색 중 오류 ({error_type}): {error_msg}"
-            )
-
-        if not points:
-            return {
-                "answer": "죄송합니다. 관련된 뉴스 정보를 찾을 수 없습니다.",
-                "reference_news": [],
-            }
-
-        # 3. 검색된 뉴스들로 컨텍스트 생성
-        context_list = []
-        sources = []
-
-        for res in points:
-            # res가 ScoredPoint 객체인지 확인
-            if hasattr(res, "payload"):
-                payload = res.payload
-                score = res.score if hasattr(res, "score") else 0.0
-            else:
-                # 다른 형태의 결과일 경우
-                payload = res.get("payload", {}) if isinstance(res, dict) else {}
-                score = res.get("score", 0.0) if isinstance(res, dict) else 0.0
-            
-            title = payload.get("title", "제목 없음")
-            content = payload.get("content", "")
-            url = payload.get("url", "")
-
-            context_list.append(f"[{title}]\n{content}")
-            sources.append(
-                {
-                    "title": title,
-                    "url": url,
-                    "source": payload.get("source", ""),
-                    "published_at": payload.get("published_at", ""),
-                    "score": score,  # 유사도 점수
-                }
-            )
-
-        context_text = "\n\n---\n\n".join(context_list)
-
-        # 4. LLM에게 답변 요청
-        system_prompt = f"""당신은 실시간 가상자산 뉴스 전문가입니다. 
-제공된 [뉴스 정보]를 바탕으로 사용자의 질문에 친절하고 정확하게 답변하세요.
-
-중요 규칙:
-- 뉴스에 없는 내용은 절대 지어내지 마세요.
-- 모르는 내용이면 "제공된 뉴스에는 해당 정보가 없습니다"라고 답변하세요.
-- 답변은 한국어로 작성하세요.
-- 가능하면 구체적인 날짜, 숫자, 출처를 포함하세요.
-
-[뉴스 정보]:
-{context_text}
-"""
-
-        response = openai_client.chat.completions.create(
-            model="gpt-4o",  # 또는 "gpt-3.5-turbo"
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": question},
-            ],
-            temperature=0.2,  # 답변의 일관성을 위해 낮게 설정
-        )
-
-        return {
-            "answer": response.choices[0].message.content,
-            "reference_news": sources,
-        }
-
+        answer, reference_news = _ask_unified(question, limit=limit)
+        return {"answer": answer, "reference_news": reference_news}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"처리 중 오류가 발생했습니다: {str(e)}")
 
@@ -254,6 +386,98 @@ async def search_news(query: str, limit: int = 5):
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"검색 중 오류가 발생했습니다: {str(e)}")
+
+
+# --- 비트코인 거래 DuckDB + Function Calling ---
+
+DUCKDB_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "query_duckdb",
+            "description": "Bitcoin(BTC/USDT) 거래 데이터가 담긴 DuckDB에 SQL을 실행해 데이터를 조회합니다. SELECT만 허용됩니다.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "sql_query": {
+                        "type": "string",
+                        "description": (
+                            "실행할 SQL 문. 테이블명은 'trades'이며, "
+                            "컬럼: trade_id(BIGINT), symbol(VARCHAR), price(DOUBLE), quantity(DOUBLE), "
+                            "amount(DOUBLE), side(VARCHAR: BUY/SELL), trade_time(TIMESTAMP), received_at(TIMESTAMP). "
+                            "예: 최근 1시간 평균가 → SELECT AVG(price) as avg_price FROM trades WHERE trade_time >= now() - interval '1 hour'"
+                        ),
+                    }
+                },
+                "required": ["sql_query"],
+            },
+        },
+    }
+]
+
+
+def ask_bitcoin_bot(user_question: str) -> str:
+    """
+    LLM이 query_duckdb 도구를 사용해 DuckDB에 SQL을 실행하고,
+    결과를 받아 자연어로 답변합니다.
+    """
+    response = openai_client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": user_question}],
+        tools=DUCKDB_TOOLS,
+    )
+
+    message = response.choices[0].message
+    tool_calls = message.tool_calls
+
+    if not tool_calls:
+        return message.content or "답변을 생성할 수 없습니다."
+
+    # 첫 번째 tool_call만 처리 (필요 시 루프로 확장)
+    for tool_call in tool_calls:
+        if tool_call.function.name != "query_duckdb":
+            continue
+        try:
+            args = json.loads(tool_call.function.arguments)
+            sql = args.get("sql_query", "")
+        except json.JSONDecodeError:
+            return "Error: Invalid tool arguments."
+        db_result = query_duckdb(sql)
+
+        final_response = openai_client.chat.completions.create(
+            model="gpt-4o",
+            messages=[
+                {"role": "user", "content": user_question},
+                message,
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": db_result,
+                },
+            ],
+        )
+        return final_response.choices[0].message.content or "답변을 생성할 수 없습니다."
+
+    return message.content or "답변을 생성할 수 없습니다."
+
+
+@app.get("/ask-bitcoin")
+async def ask_bitcoin(question: str):
+    """
+    비트코인 거래 데이터(MinIO Silver Parquet) 기반 질의응답.
+    DuckDB In-Memory + read_parquet로 MinIO를 조회합니다 (Lock 없음).
+    """
+    if not question or not question.strip():
+        raise HTTPException(status_code=400, detail="질문을 입력하세요.")
+
+    try:
+        answer = ask_bitcoin_bot(question)
+        return {"answer": answer}
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"처리 중 오류가 발생했습니다: {str(e)}",
+        )
 
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
     # 로그 실시간 출력을 위해 -u (unbuffered) 옵션 사용
     command: ["python", "-u", "kafka_fin/consumer/news_refine_stream_pandas.py"]
 
-  # 6-2. Kafka Consumer (비트코인 거래 → Bronze/Silver/DuckDB)
+  # 6-2. Kafka Consumer (비트코인 거래 → MinIO Bronze/Silver Parquet)
   trade-consumer:
     build:
       context: .
@@ -168,9 +168,6 @@ services:
       - MINIO_ACCESS_KEY=admin
       - MINIO_SECRET_KEY=password123
       - MINIO_BUCKET=trade-lake
-      - DUCKDB_PATH=/app/data/bitcoin_analytics.db
-    volumes:
-      - ./trade_data:/app/data  # DuckDB 파일 영속화
     depends_on:
       kafka:
         condition: service_healthy

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -9,8 +9,8 @@ st.set_page_config(
     layout="wide",
 )
 
-st.title("🤖 가상자산 뉴스 챗봇")
-st.markdown("실시간 수집된 뉴스를 바탕으로 답변합니다.")
+st.title("🤖 가상자산 챗봇")
+st.markdown("뉴스나 비트코인 거래 데이터를 한 번에 물어보세요. 질문에 맞춰 자동으로 검색·조회합니다.")
 
 # API 설정
 API_BASE_URL = st.sidebar.text_input(
@@ -27,10 +27,9 @@ if "messages" not in st.session_state:
 with st.sidebar:
     st.header("ℹ️ 정보")
     st.markdown("""
-    이 챗봇은 다음 기능을 제공합니다:
-    - 실시간 가상자산 뉴스 검색
-    - 뉴스 기반 질의응답
-    - 참고 뉴스 출처 제공
+    한 질문으로 다음을 모두 처리합니다:
+    - **뉴스**: 실시간 가상자산 뉴스 검색·질의응답, 참고 뉴스 출처
+    - **비트코인 거래**: 평균가·거래량 등 DuckDB 집계 질의
     """)
     
     # API 상태 확인
@@ -68,7 +67,7 @@ for message in st.session_state.messages:
                         st.divider()
 
 # 사용자 입력 받기
-if prompt := st.chat_input("궁금한 코인 소식을 물어보세요! (예: 비트코인 가격은 어떻게 되나요?)"):
+if prompt := st.chat_input("뉴스나 비트코인 거래 데이터를 물어보세요 (예: 비트코인 뉴스, 최근 1시간 평균가)"):
     # 사용자 메시지 추가 및 표시
     st.session_state.messages.append({"role": "user", "content": prompt})
     with st.chat_message("user"):
@@ -76,13 +75,12 @@ if prompt := st.chat_input("궁금한 코인 소식을 물어보세요! (예: �
 
     # FastAPI 서버에 요청
     with st.chat_message("assistant"):
-        with st.spinner("뉴스를 분석 중입니다..."):
+        with st.spinner("답변을 생성 중입니다..."):
             try:
-                # API 호출
                 response = requests.get(
                     f"{API_BASE_URL}/ask",
                     params={"question": prompt, "limit": 3},
-                    timeout=30,
+                    timeout=60,
                 )
                 response.raise_for_status()  # HTTP 에러 체크
                 

--- a/kafka_fin/consumer/bitcoin_trade_stream.py
+++ b/kafka_fin/consumer/bitcoin_trade_stream.py
@@ -1,10 +1,9 @@
 """
 Bitcoin Trade Stream Consumer
 
-Binance BTC/USDT 거래 데이터를 Kafka에서 소비하여:
-1. Bronze Layer: 원본 JSON을 그대로 Parquet로 저장
-2. Silver Layer: 정제된 데이터를 Parquet로 저장
-3. DuckDB: 실시간 분석용 테이블에 적재 (Upsert)
+Binance BTC/USDT 거래 데이터를 Kafka에서 소비하여 MinIO에 Parquet로 저장합니다.
+- Bronze Layer: 원본 JSON을 그대로 Parquet로 저장
+- Silver Layer: 정제된 데이터를 Parquet로 저장 (Backend는 MinIO Silver를 DuckDB read_parquet로 조회)
 
 사용 예시:
     # Docker 내부 실행 (환경변수로 설정됨)
@@ -22,7 +21,6 @@ from io import BytesIO
 from typing import List, Dict, Any
 
 import pandas as pd
-import duckdb
 from kafka import KafkaConsumer
 import boto3
 
@@ -45,14 +43,9 @@ MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "password123")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trade-lake")
 
-# DuckDB 설정
-# - Docker 내부에서는 /app/data에 저장
-# - 로컬에서는 현재 디렉토리에 저장
-DUCKDB_PATH = os.getenv("DUCKDB_PATH", "bitcoin_analytics.db")
-
 # S3 경로
 BRONZE_PREFIX = "bronze"  # 원본 데이터
-SILVER_PREFIX = "silver"  # 정제 데이터
+SILVER_PREFIX = "silver"  # 정제 데이터 (Backend DuckDB가 read_parquet로 조회)
 
 
 # =============================================================================
@@ -78,32 +71,6 @@ def ensure_bucket_exists(s3) -> None:
     except Exception:
         s3.create_bucket(Bucket=MINIO_BUCKET)
         print(f"[MinIO] Created bucket: {MINIO_BUCKET}")
-
-
-# =============================================================================
-# DuckDB 초기화
-# =============================================================================
-
-def init_duckdb() -> duckdb.DuckDBPyConnection:
-    """DuckDB 연결 생성 및 테이블 초기화"""
-    con = duckdb.connect(DUCKDB_PATH)
-    
-    # trades 테이블 생성 (trade_id를 PK로 사용하여 멱등성 보장)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS trades (
-            trade_id BIGINT PRIMARY KEY,
-            symbol VARCHAR,
-            price DOUBLE,
-            quantity DOUBLE,
-            amount DOUBLE,
-            side VARCHAR,
-            trade_time TIMESTAMP,
-            received_at TIMESTAMP
-        )
-    """)
-    
-    print(f"[DuckDB] Initialized at {DUCKDB_PATH}")
-    return con
 
 
 # =============================================================================
@@ -234,49 +201,18 @@ def write_to_minio(df: pd.DataFrame, s3, prefix: str, file_prefix: str) -> None:
         print(f"[MinIO] Wrote {len(group)} records to s3://{MINIO_BUCKET}/{key}")
 
 
-def write_to_duckdb(df: pd.DataFrame, con: duckdb.DuckDBPyConnection) -> None:
-    """Silver DataFrame을 DuckDB에 Upsert (trade_id 기준 중복 무시)"""
-    if df.empty:
-        return
-    
-    # DuckDB에 저장할 컬럼만 선택
-    db_cols = ["trade_id", "symbol", "price", "quantity", "amount", "side", "trade_time", "received_at"]
-    save_df = df[db_cols].copy()
-    
-    # DataFrame을 임시 테이블로 등록
-    con.register("temp_trades", save_df)
-    
-    # INSERT OR IGNORE: trade_id 중복 시 무시 (멱등성)
-    con.execute("""
-        INSERT OR IGNORE INTO trades 
-        SELECT * FROM temp_trades
-    """)
-    
-    # 임시 테이블 해제
-    con.unregister("temp_trades")
-    
-    print(f"[DuckDB] Upserted {len(save_df)} records")
-
-
-def save_batch(
-    raw_buffer: List[Dict[str, Any]],
-    s3,
-    con: duckdb.DuckDBPyConnection,
-) -> None:
-    """배치를 Bronze, Silver, DuckDB에 저장"""
+def save_batch(raw_buffer: List[Dict[str, Any]], s3) -> None:
+    """배치를 Bronze, Silver(MinIO Parquet)에 저장"""
     now = datetime.now(timezone.utc)
-    
+
     # 1. Bronze 저장 (원본 JSON)
     bronze_df = transform_to_bronze(raw_buffer)
     write_to_minio(bronze_df, s3, BRONZE_PREFIX, "raw")
-    
-    # 2. Silver 저장 (정제 데이터)
+
+    # 2. Silver 저장 (정제 데이터, Backend가 read_parquet로 조회)
     silver_df = transform_to_silver(raw_buffer)
     write_to_minio(silver_df, s3, SILVER_PREFIX, "trades")
-    
-    # 3. DuckDB 저장 (실시간 분석용)
-    write_to_duckdb(silver_df, con)
-    
+
     print(f"[Batch Complete] {len(raw_buffer)} records processed at {now.isoformat()}")
 
 
@@ -286,72 +222,54 @@ def save_batch(
 
 def consume_and_process(batch_size: int = 100, max_batches: int = None) -> None:
     """
-    Kafka에서 거래 데이터를 읽어 Bronze/Silver/DuckDB에 저장
-    
+    Kafka에서 거래 데이터를 읽어 MinIO Bronze/Silver(Parquet)에 저장
+
     Args:
         batch_size: 배치 크기 (이 개수만큼 모이면 저장)
         max_batches: 최대 배치 수 (None이면 무한 실행)
     """
     print(f"[START] Connecting Kafka at {KAFKA_BOOTSTRAP_SERVERS}, topic={KAFKA_TOPIC}")
     print(f"[START] MinIO endpoint: {MINIO_ENDPOINT}, bucket: {MINIO_BUCKET}")
-    print(f"[START] DuckDB path: {DUCKDB_PATH}")
-    
-    # Kafka Consumer 초기화
+
     consumer = KafkaConsumer(
         KAFKA_TOPIC,
         bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS,
-        auto_offset_reset="latest",  # 최신 메시지부터 소비
+        auto_offset_reset="latest",
         enable_auto_commit=True,
         value_deserializer=lambda v: v.decode("utf-8"),
     )
-    
     print(f"[Kafka] Connected! Consuming from {KAFKA_TOPIC} (batch_size={batch_size})")
-    
-    # MinIO 클라이언트 초기화
+
     s3 = create_minio_client()
     ensure_bucket_exists(s3)
-    
-    # DuckDB 초기화
-    con = init_duckdb()
-    
-    # 버퍼 및 카운터
+
     buffer: List[Dict[str, Any]] = []
     batch_count = 0
-    
+
     try:
         for msg in consumer:
-            # 메시지 파싱
             try:
                 payload = json.loads(msg.value)
                 buffer.append(payload)
             except json.JSONDecodeError:
                 print(f"[WARN] Invalid JSON skipped: {msg.value[:100]}")
                 continue
-            
-            # 배치 크기 도달 시 저장
+
             if len(buffer) >= batch_size:
                 batch_count += 1
                 print(f"\n[Batch {batch_count}] Processing {len(buffer)} records...")
-                
-                save_batch(buffer, s3, con)
+                save_batch(buffer, s3)
                 buffer.clear()
-                
-                # 최대 배치 수 도달 시 종료
                 if max_batches is not None and batch_count >= max_batches:
                     print("[INFO] Reached max_batches, exiting.")
                     break
-                    
     except KeyboardInterrupt:
         print("\n[INFO] Interrupted by user, flushing remaining records...")
     finally:
-        # 남은 버퍼 저장
         if buffer:
             print(f"[Final Batch] Processing {len(buffer)} records...")
-            save_batch(buffer, s3, con)
-        
-        # 리소스 정리
+            save_batch(buffer, s3)
         consumer.close()
-        con.close()
         print("[SHUTDOWN] Consumer closed gracefully")
 
 


### PR DESCRIPTION
### Goals
1) text-to-sql 
   
    - Workflow: user question → llm decision → execute sql → return value with llm's answer
    - Key Components:

        - [x] use function calling(llm call function when needed) 
        - [x] context injection(table scheema)
        - [ ] make read-only connection to duck db
        
       
2) changes
    - Issue: access to duck db in the same time( from kafka consumer and backend) is not allowed
    - Solution: read btc data directly from minio using duck-db as query-engine instead of conncecting to duck-db
         - [x] read btc data and send query using duck-db


       